### PR TITLE
add last update datetime of the skills to the bottom of the screen

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,8 +25,33 @@ from .skill import Wallpaper, WallpaperError
 
 FIFTEEN_MINUTES = 900
 MARK_II = "mycroft_mark_2"
+ONE_HOUR = 3600
 ONE_MINUTE = 60
 TEN_SECONDS = 10
+
+
+def _find_latest_skill_update(skill_info: dict) -> str:
+    """Returns a string representation of the last time a skill was updated.
+
+    Args:
+        skill_info: contents of the installed skill data file built by MSM
+    """
+    latest_update = 0
+    for skill_attributes in skill_info["skills"]:
+        installed_timestamp = skill_attributes["installed"]
+        updated_timestamp = skill_attributes["updated"]
+        if installed_timestamp > latest_update:
+            latest_update = installed_timestamp
+        if updated_timestamp > latest_update:
+            latest_update = updated_timestamp
+
+    if latest_update:
+        latest_update_datetime = datetime.fromtimestamp(latest_update)
+        skill_update_datetime = latest_update_datetime.strftime("%Y-%m-%d %H:%M")
+    else:
+        skill_update_datetime = ""
+
+    return skill_update_datetime
 
 
 class HomescreenSkill(MycroftSkill):
@@ -57,6 +82,10 @@ class HomescreenSkill(MycroftSkill):
             platform = self.config_core["enclosure"].get("platform")
 
         return platform
+
+    @property
+    def is_development_device(self):
+        return self.config_core["enclosure"].get("development_device")
 
     def _handle_settings_change(self):
         """Reacts to changes in the user settings for this skill."""
@@ -91,6 +120,7 @@ class HomescreenSkill(MycroftSkill):
         self._init_wallpaper()
         self._schedule_clock_update()
         self._schedule_date_update()
+        self._schedule_skill_datetime_update()
         self._add_event_handlers()
 
     def _init_gui_attributes(self):
@@ -131,6 +161,23 @@ class HomescreenSkill(MycroftSkill):
             self.update_date, when=date_update_start_time, frequency=ONE_MINUTE
         )
 
+    def _schedule_skill_datetime_update(self):
+        """Check for a weather update every fifteen minutes."""
+        self.schedule_repeating_event(
+            self.update_skill_datetime, when=datetime.now(), frequency=ONE_HOUR
+        )
+
+    def update_skill_datetime(self):
+        """Sets the skill update date for display on the home screen."""
+        skill_update_datetime = ""
+        skill_info_path = Path("~/.mycroft/skills.json").expanduser()
+        if self.is_development_device and skill_info_path.is_file():
+            with open(skill_info_path) as skill_info_file:
+                skill_info = json.loads(skill_info_file.read())
+                skill_update_datetime = _find_latest_skill_update(skill_info)
+
+        self.gui["skillDateTime"] = skill_update_datetime
+
     def _add_event_handlers(self):
         """Defines the events this skill will listen for and their handlers."""
         self.add_event("skill.alarm.query-active.response", self.handle_alarm_status)
@@ -150,14 +197,14 @@ class HomescreenSkill(MycroftSkill):
             self.request_weather, when=datetime.now(), frequency=FIFTEEN_MINUTES
         )
 
-    def request_weather(self):
-        """Emits a command over the message bus to get the local weather forecast."""
-        command = Message("skill.weather.request-local-forecast")
-        self.bus.emit(command)
-
     def query_active_alarms(self):
         """Emits a command over the message bus query for active alarms."""
         command = Message("skill.alarm.query-active")
+        self.bus.emit(command)
+
+    def request_weather(self):
+        """Emits a command over the message bus to get the local weather forecast."""
+        command = Message("skill.weather.request-local-forecast")
         self.bus.emit(command)
 
     def handle_local_forecast_response(self, event: Message):
@@ -175,23 +222,22 @@ class HomescreenSkill(MycroftSkill):
         self.log.debug("Displaying the idle screen.")
         self.update_clock()
         self.update_date()
-        self._set_build_date()
+        self._set_build_datetime()
         self._show_page()
 
-    def _set_build_date(self):
+    def _set_build_datetime(self):
         """Sets the build date on the screen from a file, if it exists.
 
         The build date won't change without a reboot.  This only needs to occur once.
         """
-        build_date = ""
+        build_datetime = ""
         build_info_path = Path("/etc/mycroft/build-info.json")
-        is_development_device = self.config_core["enclosure"].get("development_device")
-        if is_development_device and build_info_path.is_file():
+        if self.is_development_device and build_info_path.is_file():
             with open(build_info_path) as build_info_file:
                 build_info = json.loads(build_info_file.read())
-                build_date = build_info.get("build_date", "")
+                build_datetime = build_info.get("build_date", "")
 
-        self.gui["buildDate"] = build_date
+        self.gui["buildDateTime"] = build_datetime[:-3]
 
     def _show_page(self):
         """Show the appropriate home screen based on the device platform."""

--- a/ui/mark_ii_idle.qml
+++ b/ui/mark_ii_idle.qml
@@ -75,16 +75,29 @@ Mycroft.Delegate {
             width: gridUnit * 3
         }
 
-        // The date of the most recent Mark II build.  Only displayed for developers.
+        // The date and time of the most recent Mark II build.  Only displayed for developers.
         HomeScreenLabel {
-            id: homeScreenBuildDate
+            id: homeScreenBuildDateTime
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             anchors.leftMargin: gridUnit * 5
             fontSize: 22
             fontStyle: "Regular"
             heightUnits: 3
-            text: sessionData.buildDate
+            text: sessionData.buildDateTime ? "Build: " + sessionData.buildDateTime : ""
+            width: gridUnit * 10
+        }
+
+        // The date and time of the most recent skill update.  Only displayed for developers.
+        HomeScreenLabel {
+            id: homeScreenSkillDateTime
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.leftMargin: gridUnit * 30
+            fontSize: 22
+            fontStyle: "Regular"
+            heightUnits: 3
+            text: sessionData.skillDateTime ? "Skills: " + sessionData.skillDateTime : ""
             width: gridUnit * 10
         }
 

--- a/ui/scalable_idle.qml
+++ b/ui/scalable_idle.qml
@@ -227,14 +227,14 @@ Mycroft.CardDelegate {
     
     Label {
         id: buildDate
-        visible: sessionData.buildDate === "" ? 0 : 1
-        enabled: sessionData.buildDate === "" ? 0 : 1
+        visible: sessionData.buildDateTime === "" ? 0 : 1
+        enabled: sessionData.buildDateTime === "" ? 0 : 1
         anchors.left: parent.left
         anchors.bottom: parent.bottom
         anchors.bottomMargin: -Mycroft.Units.gridUnit * 2
         font.pixelSize: 22
         wrapMode: Text.WordWrap
-        text: "BI " + sessionData.buildDate
+        text: "BI " + sessionData.buildDateTime
         color: "white"
         layer.enabled: true
         layer.effect: DropShadow {


### PR DESCRIPTION
#### Description
To help with the new temporary skill deployment plan of deploying skills to the Mark II once a day, add the last skill update date and time to the Home Screen next to the build date and time at the bottom of the screen.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [ ] Bugfix
- [X] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
The skill update date and time should show up on the home screen and match the most recent timestamp in the `~/.mycroft/skills.json` file.

#### Documentation
The code is well documented.

