### PR TITLE
send command to Mark II skill to show the resting screen 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -123,6 +123,7 @@ class HomescreenSkill(MycroftSkill):
         self.schedule_weather_request()
         self.query_active_alarms()
         self._schedule_skill_datetime_update()
+        self.handle_initial_skill_load()
         self._add_event_handlers()
 
     def _init_gui_attributes(self):
@@ -196,7 +197,7 @@ class HomescreenSkill(MycroftSkill):
         )
 
     def handle_initial_skill_load(self):
-        """Queries other skills for data after all skills are loaded.
+        """Queries other skills for data to display and shows the resting screen.
 
         There is no guarantee of skill loading order.  These queries will ensure the
         home screen has the data it needs for the display when core is started or
@@ -204,6 +205,7 @@ class HomescreenSkill(MycroftSkill):
         """
         self.request_weather()
         self.query_active_alarms()
+        self.bus.emit(Message("mycroft.device.show.idle"))
 
     def query_active_alarms(self):
         """Emits a command over the message bus query for active alarms."""


### PR DESCRIPTION
#### Description
When this skill reloads, the screen goes blank.  It was not executing any logic to make the screen show up again.

Leverage the `mycroft.device.show.idle` message type to tell the Mark II skill to display the idle screen after reload.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Reload this skill, the resting screen should reappear after a short time.

#### Documentation
N/A
