### PR TITLE
change methodology for determining the skill update date and time.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+GitPython


### PR DESCRIPTION
#### Description
The old method of getting the most recent skill updates was using a method that produced inconsistent results.  Change the method to use the cloned `mycroft-skill` repository found in `/opt/mycroft/.skills-repo`.  Get the first Git log message and extract the timestamp from it.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Date and time of most recent commit to the `mycroft-skill` repository is reflected on the Home Screen.

#### Documentation
N/A
