### PR TITLE
Use configurable .skills-repo path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -162,7 +162,7 @@ class HomescreenSkill(MycroftSkill):
         this to determine the last time MSM updated any skills.
         """
         if self.is_development_device:
-            skills_repo = Git("/opt/mycroft/.skills-repo")
+            skills_repo = Git(f"{self.config_core['data_dir']}/.skills-repo")
             last_commit_timestamp = skills_repo.log("-1", "--format=%ct")
             last_commit_date_time = datetime.utcfromtimestamp(
                 int(last_commit_timestamp)


### PR DESCRIPTION
#### Description
This path was set to a hard coded value however the path is configurable in `mycroft.conf`

Thanks to @j1nx for spotting this!

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Skills timestamp should continue to show on screen if you have a Mark II with the dev device flag active.

#### CLA
- [x] Yes